### PR TITLE
Fixed truncation of long retweets

### DIFF
--- a/juiz-last-tweet.php
+++ b/juiz-last-tweet.php
@@ -470,7 +470,7 @@ class Juiz_Last_Tweet_Widget extends WP_Widget {
 						$i = 0;
 						foreach ( $rss_i as $tweet ) {
 							$i++;
-							if ($tweet -> retweeted_status -> text == ''){
+							if (!isset($tweet -> retweeted_status)){
 							  $tweet_text = $is_object ? $tweet -> text : $tweet['text'];
 							  $i_title	= jltw_format_tweettext($tweet_text, $username);
 							}else{

--- a/juiz-last-tweet.php
+++ b/juiz-last-tweet.php
@@ -470,6 +470,15 @@ class Juiz_Last_Tweet_Widget extends WP_Widget {
 						$i = 0;
 						foreach ( $rss_i as $tweet ) {
 							$i++;
+							if ($tweet -> retweeted_status -> text == ''){
+							  $tweet_text = $is_object ? $tweet -> text : $tweet['text'];
+							  $i_title	= jltw_format_tweettext($tweet_text, $username);
+							}else{
+							  $tweet_text = $is_object ? $tweet -> retweeted_status -> text : $tweet['retweeted_status']['text'];
+							  $rt_tweet_user_mentions = $is_object ? $tweet-> entities -> user_mentions : $tweet['entities']['user_mentions'];
+							  $rt_tweet_screen_name = $rt_tweet_user_mentions[0] -> screen_name;
+							  $i_title	= jltw_format_tweettext('RT @' . $rt_tweet_screen_name . ': ' . $tweet_text, $username);
+							}
 							$tweet_text = $is_object ? $tweet -> text : $tweet['text'];
 							$tweet_creat= $is_object ? $tweet -> created_at : $tweet['created_at'];
 							$screename 	= $is_object ? $tweet -> user -> screen_name : $tweet['user']['screen_name'];
@@ -477,7 +486,7 @@ class Juiz_Last_Tweet_Widget extends WP_Widget {
 							$tweet_src	= $is_object ? $tweet -> source : $tweet['source'];
 
 							$i_source	= '';
-							$i_title	= jltw_format_tweettext($tweet_text, $username);
+							//$i_title	= jltw_format_tweettext($tweet_text, $username);
 							$i_creat	= jltw_format_since( $tweet_creat );
 							$i_guid		= "http://twitter.com/".$screename."/status/".$id_str;
 							$i_source	= '<span class="juiz_ltw_source">'.__('via','jltw_lang').' '. jltw_format_tweetsource( $tweet_src ) . '</span>';


### PR DESCRIPTION
$tweet -> text is truncated in long retweets are truncated due to the addition of RT @user_name:
This is a hassel specially if the RT ends with links or hastags or mentions, wich are truncated too and you end up with broken links. 
Therefore the text for RTs should be pulled from $tweet -> retweeted_status -> text 
I added some code to mantain the  RT @user_name: too ;)
